### PR TITLE
Fix missing semicolons and newline in site.js

### DIFF
--- a/site.js
+++ b/site.js
@@ -138,11 +138,11 @@ function dropHandler(ev) {
   // }
 }
 
-window.dropHandler = dropHandler
+window.dropHandler = dropHandler;
 
 function dragOverHandler(ev) {
   // Prevent default behavior (Prevent file from being opened)
   ev.preventDefault();
 }
 
-window.dragOverHandler = dragOverHandler
+window.dragOverHandler = dragOverHandler;


### PR DESCRIPTION
## Summary
- add semicolons after window handler assignments
- ensure site.js ends with a newline

## Testing
- `tail -c 1 site.js | od -t x1`

------
https://chatgpt.com/codex/tasks/task_e_6863a7d9e4ec832b992add4e25fc62de