### PR TITLE
Add playful landing page and random room generator

### DIFF
--- a/landing.css
+++ b/landing.css
@@ -1,0 +1,87 @@
+body {
+  font-family: 'Comic Sans MS', Arial, sans-serif;
+  color: #333;
+  margin: 0;
+  padding: 0;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(135deg, #ff9a9e 0%, #fad0c4 50%, #fbc2eb 100%);
+}
+
+header {
+  background-color: rgba(255, 255, 255, 0.9);
+  padding: 2rem;
+  text-align: center;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.1);
+}
+
+header h1 {
+  margin: 0;
+  font-size: 3rem;
+  color: #ff5588;
+}
+
+main {
+  flex: 1;
+  padding: 2rem;
+  max-width: 960px;
+  margin: 0 auto;
+  text-align: center;
+}
+
+section {
+  margin-bottom: 2rem;
+}
+
+.feature-list {
+  list-style: none;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.feature-list li {
+  margin-bottom: 1rem;
+  display: flex;
+  align-items: center;
+  font-size: 1.2rem;
+}
+
+.feature-list img {
+  width: 40px;
+  height: 40px;
+  margin-right: 0.5rem;
+}
+
+#gen-room {
+  background-color: #ff5588;
+  border: none;
+  color: #fff;
+  padding: 1rem 2rem;
+  font-size: 1.2rem;
+  border-radius: 40px;
+  cursor: pointer;
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+#gen-room:hover {
+  background-color: #ff3366;
+}
+
+#room-link {
+  margin-top: 1rem;
+  font-weight: bold;
+}
+
+.hidden {
+  display: none;
+}
+
+footer {
+  text-align: center;
+  padding: 1rem;
+  background-color: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 -4px 10px rgba(0, 0, 0, 0.1);
+}

--- a/landing.html
+++ b/landing.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Droppa.li - Secure P2P Sharing</title>
+    <link href="images/favicon.png" rel="icon" />
+    <link rel="stylesheet" href="landing.css" />
+  </head>
+  <body>
+    <header>
+      <h1>🪂 Droppa.li</h1>
+    </header>
+    <main>
+      <section class="intro">
+        <p>
+          Droppa.li lets you share files and clipboard text directly with peers using WebRTC.
+          No server in the middle, just quick and private transfers.
+        </p>
+      </section>
+      <section class="features">
+        <ul class="feature-list">
+          <li><img src="images/hand.png" alt="hand" />Easy drag-and-drop file sharing</li>
+          <li><img src="images/hand.png" alt="hand" />Send clipboard text with one click</li>
+          <li><img src="images/hand.png" alt="hand" />Peer-to-peer connections for privacy</li>
+        </ul>
+      </section>
+      <section class="room-gen">
+        <button id="gen-room">✨ Create Magic Room ✨</button>
+        <p id="room-link" class="hidden"></p>
+      </section>
+      <section class="join">
+        <p><a href="index.html">Join an existing room</a></p>
+      </section>
+    </main>
+    <footer>
+      &copy; 2025 Droppa.li
+    </footer>
+    <script>
+      const words = [
+        'orange','panda','sparkle','rocket','rainbow','banana','unicorn','taco',
+        'kebab','piano','pizza','coffee','bubble','cloud','dragon','salsa',
+        'zebra','fluffy','ninja','pickle'
+      ];
+      const button = document.getElementById('gen-room');
+      const linkEl = document.getElementById('room-link');
+      function randomName() {
+        const arr = [];
+        for (let i = 0; i < 3; i++) {
+          arr.push(words[Math.floor(Math.random() * words.length)]);
+        }
+        return arr.join('-');
+      }
+      button.addEventListener('click', () => {
+        const name = randomName();
+        const base = window.location.href.replace(/landing\.html.*/, '');
+        const url = `${base}index.html?${name}`;
+        navigator.clipboard.writeText(url).then(() => {
+          linkEl.textContent = `Link copied! ${url}`;
+          linkEl.classList.remove('hidden');
+        }).catch(() => {
+          linkEl.textContent = url;
+          linkEl.classList.remove('hidden');
+        });
+      });
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- redesign landing page with a brighter color scheme
- add "Create Magic Room" button that generates whimsical URLs and copies them to the clipboard
- style landing page with playful fonts and gradient background

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6863aba471fc832ba4457de3648b2d57